### PR TITLE
batch() - usage example fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,12 +550,11 @@ age.set(25)
 city.set("Boston")
 
 # With batch - prints only once at the end
-def update_person():
+with batch()
     name.set("Charlie")
     age.set(35)
     city.set("Chicago")
-
-batch(update_person)  # Only prints once: "Charlie, 35, Chicago"
+# Only prints once: "Charlie, 35, Chicago"
 ```
 
 ### Error Handling

--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ age.set(25)
 city.set("Boston")
 
 # With batch - prints only once at the end
-with batch()
+with batch():
     name.set("Charlie")
     age.set(35)
     city.set("Chicago")


### PR DESCRIPTION
batch() - usage example fix, batch is a context manager, not a function